### PR TITLE
Add useMiddleEnd hook, tests, build WIP

### DIFF
--- a/API.md
+++ b/API.md
@@ -163,3 +163,59 @@ The `indexes` branch keeps a dictionary of indexes to store the status and resul
 Indexing can be skipped by configuring `shouldIndex` to `false` or a function returning `true` or `false` given the index name.  Indexes are initialized in the store lazily, i.e. when they are first seen on an action's `meta.index` property.
 
 Typically `entities` and `indexes` work in tandem to keep track of normalized results from an external data-source while keeping them properly normalized.
+
+## React Bindings
+
+#### `<Provider middleEnd={app} />`
+
+React Context Provider component that handles providing the passed middle-end to any nested Context consumers.
+
+
+It requires the following prop:
+
+- `middleEnd`: A composed application that is set as the context value. The app must be initialized; the component throws otherwise
+
+```js
+const StrangeMiddleEnd = require('strange-middle-end');
+
+// const config = ... standard middle-end config e.g. input to create method
+
+function App ({ props }) {
+
+    const m = MiddleEnd.create(config).initialize();
+
+    return (
+        <MiddleEnd.Provider middleEnd={m}>
+            {/* 
+                Counter may now consume middleEnd context (see useMiddleEnd hook below) 
+            */}
+            <Counter />
+        </MiddleEnd.Provider>
+    )
+}
+```
+
+#### `useMiddleEnd`
+
+Hook that returns the current middle-end as contextualized by the nearest parent `Provider`.
+Follows the same rendering logic as [React's built-in `useContext`](https://reactjs.org/docs/hooks-reference.html#usecontext).
+
+```js
+function Counter ({ props }) {
+
+    const m = useMiddleEnd();
+
+    return (
+        <div>
+            <button onClick={() => m.dispatch.counter.increment()}>Increment</button>
+            {/* 
+                Note that this selector is NOT subscribed to our store, so will not re-render
+                the component on state change e.g. on clicking the button above.
+                For a subscribed selector, consider wrapping in react-redux's useSelector hook
+                e.g. useSelector(m.select.counter.get)
+            */}
+            {m.select.counter.get()}
+        </div>
+    )
+}
+```

--- a/API.md
+++ b/API.md
@@ -208,13 +208,47 @@ function Counter ({ props }) {
     return (
         <div>
             <button onClick={() => m.dispatch.counter.increment()}>Increment</button>
-            {/* 
-                Note that this selector is NOT subscribed to our store, so will not re-render
-                the component on state change e.g. on clicking the button above.
-                For a subscribed selector, consider wrapping in react-redux's useSelector hook
-                e.g. useSelector(m.select.counter.get)
-            */}
-            {m.select.counter.get()}
+        </div>
+    )
+}
+```
+
+
+If we want to subscribe to and rerender on the state changes dispatched by our button,
+we can lean on react-redux, specifically its `useSelector` hook.
+
+
+```js
+const ReactRedux = require('react-redux');
+const StrangeMiddleEnd = require('strange-middle-end');
+
+function App ({ props }) {
+
+    const m = MiddleEnd.create(config).initialize();
+
+    return (
+        <MiddleEnd.Provider middleEnd={m}>
+            <ReactRedux.Provider store={m.store}>
+                <Counter />
+            </ReactRedux.Provider>
+        </MiddleEnd.Provider>
+    )
+}
+
+// Then back in our Counter component
+
+const { useSelector } = require('react-redux');
+
+function Counter ({ props }) {
+
+    const m = useMiddleEnd();
+    // Subscribe our selector to changes in our store 
+    const count = useSelector(m.select.counter.get);
+
+    return (
+        <div>
+            <p>The count is {count}</p>
+            <button onClick={() => m.dispatch.counter.increment()}>Increment</button>
         </div>
     )
 }

--- a/API.md
+++ b/API.md
@@ -173,7 +173,7 @@ React Context Provider component that handles providing the passed middle-end to
 
 It requires the following prop:
 
-- `middleEnd`: A composed application that is set as the context value. The app must be initialized; the component throws otherwise
+- `middleEnd` - A composed application that is set as the context value. The app must be initialized; the component throws otherwise.
 
 ```js
 const StrangeMiddleEnd = require('strange-middle-end');

--- a/API.md
+++ b/API.md
@@ -243,7 +243,7 @@ function Counter ({ props }) {
 
     const m = useMiddleEnd();
     // Subscribe our selector to changes in our store 
-    const count = useSelector(m.select.counter.get);
+    const count = useSelector(m.selectors.counter.get);
 
     return (
         <div>

--- a/API.md
+++ b/API.md
@@ -195,7 +195,7 @@ function App ({ props }) {
 }
 ```
 
-#### `useMiddleEnd`
+#### `useMiddleEnd()`
 
 Hook that returns the current middle-end as contextualized by the nearest parent `Provider`.
 Follows the same rendering logic as [React's built-in `useContext`](https://reactjs.org/docs/hooks-reference.html#usecontext).

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const Core = require('./core');
 const Actions = require('./actions');
 const Types = require('./types');
 const Reducers = require('./reducers');
+const ReactBindings = require('./react');
 
 exports.create = Core.create;
 
@@ -28,3 +29,7 @@ exports.isTypeFail = Types.isTypeFail;
 exports.createReducer = Reducers.createReducer;
 
 exports.createEntityReducer = Reducers.createEntityReducer;
+
+exports.Provider = ReactBindings.Provider;
+
+exports.useMiddleEnd = ReactBindings.useMiddleEnd;

--- a/lib/react.js
+++ b/lib/react.js
@@ -6,7 +6,7 @@ const Context = React.createContext();
 
 Context.displayName = 'StrangeMiddleEnd';
 
-exports.Provider = ({ middleEnd, children }) => {
+exports.Provider = function Provider({ middleEnd, children }) {
 
     if (!middleEnd || !middleEnd.initialized) {
         throw new Error(

--- a/lib/react.js
+++ b/lib/react.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const React = require('react');
+
+const Context = React.createContext();
+
+Context.displayName = 'StrangeMiddleEnd';
+
+exports.Provider = ({ middleEnd, children }) => {
+
+    if (!middleEnd || !middleEnd.initialized) {
+        throw new Error(
+            'StrangeMiddleEnd.Provider received an unitialized middle-end. Please pass an initialized middle-end.'
+        );
+    }
+
+    return React.createElement(Context.Provider, {
+        value: middleEnd
+    }, children);
+};
+
+exports.useMiddleEnd = function useMiddleEnd() {
+
+    const m = React.useContext(Context);
+    if (!m) {
+        throw new Error(
+            'No middle-end found. Make sure this component is wrapped in strange-middle-end\'s <Provider>.'
+        );
+    }
+
+    return m;
+};

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "redux": ">=3 <5",
     "redux-thunk": "2.x.x",
     "immer": ">=1 <7",
-    "normalizr": "3.x.x"
+    "normalizr": "3.x.x",
+    "react": ">= 16.8.x"
   },
   "devDependencies": {
     "@babel/core": "7.x.x",
@@ -45,18 +46,21 @@
     "@hapi/code": "8.x.x",
     "@hapi/lab": "22.x.x",
     "@rollup/plugin-node-resolve": "7.x.x",
+    "@testing-library/react-hooks": "3.x.x",
     "coveralls": "3.x.x",
+    "immer": "6.x.x",
+    "normalizr": "3.x.x",
+    "npm-run-all": "4.x.x",
+    "react": "^16.8.x",
+    "react-test-renderer": "^16.8.x",
     "redux": "4.x.x",
     "redux-thunk": "2.x.x",
+    "rimraf": "3.x.x",
     "rollup": "2.x.x",
     "rollup-plugin-babel": "4.x.x",
     "rollup-plugin-cjs-es": "1.x.x",
     "rollup-plugin-filesize": "7.x.x",
     "rollup-plugin-peer-deps-external": "2.x.x",
-    "rollup-plugin-terser": "5.x.x",
-    "immer": "6.x.x",
-    "normalizr": "3.x.x",
-    "npm-run-all": "4.x.x",
-    "rimraf": "3.x.x"
+    "rollup-plugin-terser": "5.x.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "redux-thunk": "2.x.x",
     "immer": ">=1 <7",
     "normalizr": "3.x.x",
-    "react": ">= 16.8.x"
+    "react": ">=16.8.x <17"
   },
   "devDependencies": {
     "@babel/core": "7.x.x",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "build": "npm run clean && rollup -c",
     "clean": "rimraf dist",
-    "test": "lab -a @hapi/code -t 100 -L",
-    "lint": "lab -dL",
+    "test": "lab -a @hapi/code -t 100 -L -I 'regeneratorRuntime'",
+    "lint": "lab -dL -I 'regeneratorRuntime'",
     "coveralls": "lab -r lcov | coveralls"
   },
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -45,7 +45,8 @@ module.exports = [
                 immer: 'immer',
                 normalizr: 'normalizr',
                 redux: 'Redux',
-                'redux-thunk': 'ReduxThunk'
+                'redux-thunk': 'ReduxThunk',
+                react: 'React'
             }
         },
         plugins: [

--- a/test/index.js
+++ b/test/index.js
@@ -24,7 +24,9 @@ describe('StrangeMiddleEnd', () => {
             'isTypeSuccess',
             'isTypeFail',
             'createReducer',
-            'createEntityReducer'
+            'createEntityReducer',
+            'useMiddleEnd',
+            'Provider'
         ]);
     });
 

--- a/test/react.js
+++ b/test/react.js
@@ -100,7 +100,7 @@ describe('React', () => {
                 }
             });
 
-            expect(result.current).to.equal(m2);
+            expect(result.current).to.shallow.equal(m2);
 
 
             const M = ({ count, dispatch, id }) => {
@@ -139,12 +139,12 @@ describe('React', () => {
                 const { id, count, m } = el.props;
                 if (id === 'outer') {
                     expect(count).to.equal(20);
-                    expect(m).to.equal(m1);
+                    expect(m).to.shallow.equal(m1);
                 }
 
                 if (id === 'inner') {
                     expect(count).to.equal(55);
-                    expect(m).to.equal(m2);
+                    expect(m).to.shallow.equal(m2);
                 }
             });
         });
@@ -227,7 +227,7 @@ describe('React', () => {
             button.props.onClick();
         });
 
-        // Counter hasn't rerender; selector isn't subscribed, dispatch isn't effectful,
+        // Counter hasn't rerendered; selector isn't subscribed, dispatch isn't effectful,
         // so clicking didn't trigger a rerender
         [button, text] = tree.root.findByType(Counter).children[0].children;
         expect(m.select.counter.get()).to.equal(1);

--- a/test/react.js
+++ b/test/react.js
@@ -70,7 +70,7 @@ describe('React', () => {
                 }
             });
 
-            expect(result.current).to.equal(middleEnd);
+            expect(result.current).to.shallow.equal(middleEnd);
 
             TestingHooks.act(() => {
 

--- a/test/react.js
+++ b/test/react.js
@@ -1,0 +1,246 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+const React = require('react');
+const Redux = require('redux');
+const TestingHooks = require('@testing-library/react-hooks');
+const TestRenderer = require('react-test-renderer');
+const MiddleEnd = require('../lib');
+
+const { describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+const createMiddleEnd = (init = true, initialState = 0) => {
+
+    const { INCREMENT } = MiddleEnd.createTypes({
+        INCREMENT: MiddleEnd.type.simple
+    });
+
+    const m = MiddleEnd.create({
+        mods: {
+            counter: {
+                actions: {
+                    increment: MiddleEnd.createAction(INCREMENT)
+                },
+                reducer: MiddleEnd.createReducer(initialState, {
+                    [INCREMENT]: (state) => state + 1
+                }),
+                selectors: {
+                    get: ({ counter }) => counter
+                }
+            }
+        },
+        createStore: (reducer) => Redux.createStore(reducer, Redux.applyMiddleware(MiddleEnd.middleware.thunk))
+    });
+    if (init) {
+        m.initialize();
+    }
+
+    return m;
+};
+
+describe('React', () => {
+
+    describe('useMiddleEnd', () => {
+
+        it('throws if user does not provide a middle-end.', (flags) => {
+
+            flags.onCleanup = TestingHooks.cleanup;
+
+            const { result } = TestingHooks.renderHook(() => MiddleEnd.useMiddleEnd());
+
+            expect(result.error.message).to.equal(
+                'No middle-end found. Make sure this component is wrapped in strange-middle-end\'s <Provider>.'
+            );
+        });
+
+        it('returns the provided middle-end', (flags) => {
+
+            flags.onCleanup = TestingHooks.cleanup;
+
+            const middleEnd = createMiddleEnd();
+
+            const { result } = TestingHooks.renderHook(() => MiddleEnd.useMiddleEnd(), {
+                wrapper: ({ children }) => {
+
+                    return React.createElement(MiddleEnd.Provider, {
+                        middleEnd
+                    }, children);
+                }
+            });
+
+            expect(result.current).to.equal(middleEnd);
+
+            TestingHooks.act(() => {
+
+                result.current.dispatch.counter.increment();
+            });
+
+            expect(result.current.select.counter.get()).to.equal(1);
+        });
+
+        it('returns the nearest provided middle-end', (flags) => {
+
+            flags.onCleanup = TestingHooks.cleanup;
+
+            const m1 = createMiddleEnd(true, 20);
+            const m2 = createMiddleEnd(true, 55);
+
+            const { result } = TestingHooks.renderHook(() => MiddleEnd.useMiddleEnd(), {
+                wrapper: ({ children }) => {
+
+                    return React.createElement(MiddleEnd.Provider, {
+                        middleEnd: m1
+                    },
+                    React.createElement(MiddleEnd.Provider, {
+                        middleEnd: m2
+                    }, children)
+                    );
+                }
+            });
+
+            expect(result.current).to.equal(m2);
+
+
+            const M = ({ count, dispatch, id }) => {
+
+                return null;
+            };
+
+            const Container = ({ id }) => {
+
+                const m = MiddleEnd.useMiddleEnd();
+                return React.createElement(M, {
+                    count: m.select.counter.get(),
+                    id,
+                    m
+                });
+            };
+
+            let tree;
+            TestRenderer.act(() => {
+
+                tree = TestRenderer.create(React.createElement(MiddleEnd.Provider, {
+                    middleEnd: m1
+                }, React.Children.toArray([
+                    React.createElement(Container, { id: 'outer' }),
+                    React.createElement(
+                        MiddleEnd.Provider,
+                        { middleEnd: m2 },
+                        React.createElement(Container, { id: 'inner' })
+                    )
+                ])
+                ));
+            });
+
+            tree.root.findAllByType(M).forEach((el) => {
+
+                const { id, count, m } = el.props;
+                if (id === 'outer') {
+                    expect(count).to.equal(20);
+                    expect(m).to.equal(m1);
+                }
+
+                if (id === 'inner') {
+                    expect(count).to.equal(55);
+                    expect(m).to.equal(m2);
+                }
+            });
+        });
+    });
+
+    describe('Provider', () => {
+
+        it('throws if falsey or uninitialized middle-end provided.', (flags) => {
+
+            const message = 'StrangeMiddleEnd.Provider received an unitialized middle-end. Please pass an initialized middle-end.';
+
+            // react-test-renderer calls console.error internally
+            // hide those from our test logs
+            const origError = console.error;
+            console.error = () => {};
+
+            flags.onCleanup = () => {
+
+                console.error = origError;
+            };
+
+            expect(() => {
+
+                TestRenderer.act(() => {
+
+                    TestRenderer.create(React.createElement(MiddleEnd.Provider));
+                });
+            }).to.throw(Error, message);
+
+            expect(() => {
+
+                const uninitialized = createMiddleEnd(false);
+                TestRenderer.act(() => {
+
+                    TestRenderer.create(React.createElement(MiddleEnd.Provider, { middleEnd: uninitialized }));
+                });
+            }).to.throw(Error, message);
+        });
+    });
+
+    it('integrates into a usual component tree.', () => {
+
+        const m = createMiddleEnd();
+
+        const Counter = () => {
+
+            const mE = MiddleEnd.useMiddleEnd();
+
+            return React.createElement('div', null,
+                React.Children.toArray([
+                    React.createElement('button', { onClick: () => mE.dispatch.counter.increment() }),
+                    mE.select.counter.get()
+                ])
+            );
+        };
+
+        const App = () => {
+
+            return React.createElement(MiddleEnd.Provider, {
+                middleEnd: m
+            }, React.createElement(Counter));
+        };
+
+        let tree;
+        TestRenderer.act(() => {
+
+            tree = TestRenderer.create(App(1));
+        });
+
+        let button;
+        let text;
+
+        // initial state
+        [button, text] = tree.root.findByType(Counter).children[0].children;
+        expect(m.select.counter.get()).to.equal(0);
+        expect(text).to.equal(String(m.select.counter.get()));
+
+        TestRenderer.act(() => {
+
+            button.props.onClick();
+        });
+
+        // Counter hasn't rerender; selector isn't subscribed, dispatch isn't effectful,
+        // so clicking didn't trigger a rerender
+        [button, text] = tree.root.findByType(Counter).children[0].children;
+        expect(m.select.counter.get()).to.equal(1);
+        expect(text).to.equal(String(0));
+
+        // force rerender
+        TestRenderer.act(() => {
+
+            tree.update(App());
+        });
+
+        [button, text] = tree.root.findByType(Counter).children[0].children;
+        expect(m.select.counter.get()).to.equal(1);
+        expect(text).to.equal(String(m.select.counter.get()));
+    });
+});


### PR DESCRIPTION
Addresses #11 
Based on / copied from @devinivy 's work hookifying strangeluv on [fishbowl](https://github.com/devinivy/fishbowl/blob/master/packages/frontend/src/middle-end/react.js)

Some items to still to address:

- API docs
- Address new globals leak (regeneratorRuntime) in tests, I believe from the hooks testing lib
- Add more / better tests?

I figure I can address all those if how I've written things, particularly the tests, looks ok enough to y'all.

Last, I'm completely unsure if these changes are building correctly. I was unable to link this version into a local strangeluv app, say an import error on webpack bundling (can post details if this isn't an expected issue). I bailed on digging into this further, since I expected the core issue is really that I was doing something wrong-headed 🤡 