### PR TITLE
Async actions preserve single array argument

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -125,7 +125,7 @@ internals.asyncAction = (actionTypes, config = {}) => {
 internals.defaultTransform = (...args) => {
 
     if (args.length <= 1) {
-        return args[0];
+        return Array.isArray(args[0]) ? [args[0]] : args[0];
     }
 
     return args;

--- a/test/actions.js
+++ b/test/actions.js
@@ -105,18 +105,33 @@ describe('Actions', () => {
             ]);
 
             expect(results).to.equal([null, { id: 1 }]);
+        });
 
-            // Extra check for special case — single array arg
-            const arrayResults = await store.dispatch(actionX([{ id: 2 }, { id: 3 }]));
+        it('preserves special case single array arguments.', async () => {
+
+            const store = createActionRecordingStore();
+
+            const { X } = MiddleEnd.createTypes({
+                X: MiddleEnd.type.async
+            });
+
+            const actionX = MiddleEnd.createAction(X, {
+
+                handler: (...args) => {
+
+                    expect(args).to.equal([[{ id: 1 }, { id: 2 }]]);
+                    return args;
+                }
+            });
+
+            const results = await store.dispatch(actionX([{ id: 1 }, { id: 2 }]));
 
             expect(store.getState()).to.equal([
-                { type: X.BEGIN, payload: { id: 1 }, meta: { index: null } },
-                { type: X.SUCCESS, payload: { id: 1 }, meta: { index: null, original: { id: 1 } } },
-                { type: X.BEGIN, payload: [[{ id: 2 }, { id: 3 }]], meta: { index: null } },
-                { type: X.SUCCESS, payload: [[{ id: 2 }, { id: 3 }]], meta: { index: null, original: [[{ id: 2 }, { id: 3 }]] } }
+                { type: X.BEGIN, payload: [[{ id: 1 }, { id: 2 }]], meta: { index: null } },
+                { type: X.SUCCESS, payload: [[{ id: 1 }, { id: 2 }]], meta: { index: null, original: [[{ id: 1 }, { id: 2 }]] } }
             ]);
 
-            expect(arrayResults).to.equal([null, [[{ id: 2 }, { id: 3 }]]]);
+            expect(results).to.equal([null, [[{ id: 1 }, { id: 2 }]]]);
         });
 
         it('creates an async action with a handler that succeeds.', async () => {

--- a/test/actions.js
+++ b/test/actions.js
@@ -107,16 +107,16 @@ describe('Actions', () => {
             expect(results).to.equal([null, { id: 1 }]);
 
             // Extra check for special case — single array arg
-            const arrayResults = await store.dispatch(actionX([{ id: 3 }, { id: 4 }]));
+            const arrayResults = await store.dispatch(actionX([{ id: 2 }, { id: 3 }]));
 
             expect(store.getState()).to.equal([
                 { type: X.BEGIN, payload: { id: 1 }, meta: { index: null } },
                 { type: X.SUCCESS, payload: { id: 1 }, meta: { index: null, original: { id: 1 } } },
-                { type: X.BEGIN, payload: [[{ id: 3 }, { id: 4 }]], meta: { index: null } },
-                { type: X.SUCCESS, payload: [[{ id: 3 }, { id: 4 }]], meta: { index: null, original: [[{ id: 3 }, { id: 4 }]] } }
+                { type: X.BEGIN, payload: [[{ id: 2 }, { id: 3 }]], meta: { index: null } },
+                { type: X.SUCCESS, payload: [[{ id: 2 }, { id: 3 }]], meta: { index: null, original: [[{ id: 2 }, { id: 3 }]] } }
             ]);
 
-            expect(arrayResults).to.equal([null, [[{ id: 3 }, { id: 4 }]]]);
+            expect(arrayResults).to.equal([null, [[{ id: 2 }, { id: 3 }]]]);
         });
 
         it('creates an async action with a handler that succeeds.', async () => {

--- a/test/actions.js
+++ b/test/actions.js
@@ -105,6 +105,18 @@ describe('Actions', () => {
             ]);
 
             expect(results).to.equal([null, { id: 1 }]);
+
+            // Extra check for special case — single array arg
+            const arrayResults = await store.dispatch(actionX([{ id: 3 }, { id: 4 }]));
+
+            expect(store.getState()).to.equal([
+                { type: X.BEGIN, payload: { id: 1 }, meta: { index: null } },
+                { type: X.SUCCESS, payload: { id: 1 }, meta: { index: null, original: { id: 1 } } },
+                { type: X.BEGIN, payload: [[{ id: 3 }, { id: 4 }]], meta: { index: null } },
+                { type: X.SUCCESS, payload: [[{ id: 3 }, { id: 4 }]], meta: { index: null, original: [[{ id: 3 }, { id: 4 }]] } }
+            ]);
+
+            expect(arrayResults).to.equal([null, [[{ id: 3 }, { id: 4 }]]]);
         });
 
         it('creates an async action with a handler that succeeds.', async () => {


### PR DESCRIPTION
Fixes https://github.com/BigRoomStudios/strange-middle-end/issues/13
Wrote a check for single arg array as a special case, then wrote a test for it